### PR TITLE
Fix assignment bug in rdomset.domination_graph

### DIFF
--- a/tests/test_rdomset.py
+++ b/tests/test_rdomset.py
@@ -3,7 +3,8 @@ import itertools
 import random
 
 from spacegraphcats.catlas.graph import Graph
-from spacegraphcats.catlas.rdomset import low_degree_orientation
+from spacegraphcats.catlas.rdomset import low_degree_orientation, domination_graph
+from sortedcontainers import SortedSet, SortedDict
 
 
 class ParserRDomset(unittest.TestCase):
@@ -76,6 +77,51 @@ class ParserRDomset(unittest.TestCase):
                 set(g.arcs(1))
             )
         )
+
+    def test_domination_graph(self):
+        r = 3
+        g = Graph(num_nodes=10, radius=r)
+
+        edges = [(0, 6), (6, 7), (6, 5), (6, 8), (5, 8), (8, 9), (8, 2), (2, 1), (2, 3), (3, 4)]
+
+        for x, y in edges:
+            g.add_arc(x, y)
+            g.add_arc(y, x)
+
+        low_degree_orientation(g)
+
+        # normal cases
+
+        # Vertices must be assigned to their closest dominators.
+        # There are no ties with the following r-dominating sets.
+        domgraph, dominated = domination_graph(g, [0, 4], r)
+        self.assertEqual(
+            dominated,
+            SortedDict({0: SortedSet([0, 5, 6, 7, 8, 9]), 4: SortedSet([1, 2, 3, 4])})
+        )
+        self.assertEqual(set(domgraph.arcs(1)), set([(0, 4), (4, 0)]))
+
+        domgraph, dominated = domination_graph(g, [3, 6], r)
+        self.assertEqual(
+            dominated,
+            SortedDict({3: SortedSet([1, 2, 3, 4]), 6: SortedSet([0, 5, 6, 7, 8, 9])})
+        )
+        self.assertEqual(set(domgraph.arcs(1)), set([(3, 6), (6, 3)]))
+
+        # Vertices 8, 9 are equidistance from the dominators, but they should be assigned to
+        # the earliest dominator, which is vertex 2. Thus, the resulting pieces should induce
+        # connected subgraphs.
+        domgraph, dominated = domination_graph(g, [2, 5, 6], r)
+        self.assertEqual(
+            dominated,
+            SortedDict({2: SortedSet([1, 2, 3, 4, 8, 9]), 5: SortedSet([5]), 6: SortedSet([0, 6, 7])})
+        )
+        self.assertEqual(set(domgraph.arcs(1)), set([(2, 5), (2, 6), (5, 2), (5, 6), (6, 2), (6, 5)]))
+
+        # error cases (should raise an error when the given vertex set is not an r-dominating set)
+        self.assertRaises(AssertionError, lambda: domination_graph(g, [], r))
+        self.assertRaises(AssertionError, lambda: domination_graph(g, [0], r))
+        self.assertRaises(AssertionError, lambda: domination_graph(g, [0, 5, 6, 7, 9], r))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## This is a dummy pull request.

### 1. Bug Report

The function `spacegraphcats.catlas.rdomset.domination_graph()` does not work as expected. There are cases where a vertex is not assigned to one of its closest dominators.

#### 1.1 Reproduction steps

##### Environment

- OS: macOS Catalina
- Python 3.9.1
- SpaceGraphCats v2.0b11

##### Code

The following code creates a path of four vertices (connected as 0-1-2-3). When we set r=1, the `rdomset()` function chooses two dominators, 0 and 3. Vertex 1's closest dominator is vertex 0, and vertex 2's closest dominator is vertex 3.

```
from io import StringIO
import spacegraphcats.catlas.graph_io as gio
import spacegraphcats.catlas.rdomset as rd

r = 1
G = gio.read_from_gxt(StringIO('4\n0 1\n1 2\n2 3'), r, False)
domset = rd.rdomset(G, r)
dg, dominated = rd.domination_graph(G, domset, r)

print(dominated)
```

##### Expected result

```
SortedDict({0: SortedSet([0, 1]), 3: SortedSet([2, 3])})
```

Each dominator should take exactly one neighbor.

##### Actual result

```
SortedDict({0: SortedSet([0, 1, 2]), 3: SortedSet([3])})
```

Vertex 2 is assigned to vertex 0. This is incorrect because the distance between vertex 0 and 2 is 2, which exceeds the value of r.

Reproducibility rate: 100% (10/10 times bug reproduced)

#### 1.2 Additional details

For each iteration in lines 276-290 in rdomset.py, a dominator should propagate the assignments to its neighborhood of one larger radius. However, it is possible to propagate more than distance 1.

For instance, if the low-degree orientation is `0 <- 1 <- 2 -> 3`, then vertex 0 propagates to vertex 1, and immediately after that, vertex 1 propagates to vertex 2 before processing vertex 3.

- What if all dominators are labeled earlier than non-dominators?
  - The same issue happens when r > 1. Example: `0 <- 2 <- 3 <- 5 -> 4 -> 1` with dominators `0,1` (5 will belong to 0)
- How bad can assignments go wrong?
  - If there is an induced path of dominators with consecutive labels (such as `1 <- 2 <- 3 <- 4 ...`), the assignment can go arbitrarily wrong.

### 2. Testing

We added unit tests to `test_rdomset.py` that fails with the current code and passes with the updated code.

### 3. Performance

We ran our [benchmarking code](https://github.com/mogproject/spacegraphcats/wiki/Benchmark) with several datasets and observed that performance is almost the same as the current version.

#### 3.1 Datasets

k: value for k-mers
|V|: number of vertices
|E|: number of vertices
|D|: number of chosen dominators with respect to the given radius

|Name|Description|k   |\|V\||\|E\||Radius  |\|D\||
|:---|:----------|:--:|----:|----:|--:|----:|
|dory|doryteuthis RNAseq assembly|21|736|357|1|580|
||       ||||2|487|
||       ||||3|486|
|two-foo|synthetic mixture of two genomes<br>(Akkermansia and Shewanella baltica OS 223)|31|205,891|208,793|1|125,324|
||       ||||2|83,436|
||       ||||3|80,344|

#### 3.2 Environment

- macOS Catalina Version 10.15.7
- 2.9 GHz Quad-Core Intel Core i7
- 16 GB 2133 MHz LPDDDR3
- We measured with Python's `timeit` module and recorded the best performance among 5 rounds, where each round consists of 10 iterations of function calls.

#### 3.3 Measurement result

|Name|k|Radius|Current Version|Fixed Version|
|:-----|:--:|:--:|--:|--:|
|dory|21|1|17.8 ms|18.2 ms|
|dory|21|2|16.9 ms|15.7 ms|
|dory|21|3|17.1 ms|15.5 ms|
|twofoo|31|1|5.91 sec|6.25 sec|
|twofoo|31|2|5.03 sec|5.06 sec|
|twofoo|31|3|5.57 sec|4.84 sec|

We observed almost the same performance with the current and fixed versions although there is some overhead with radius=1. On average, the fixed version outperforms the current version when radius is larger than 1.

### 4. Statistics

This fix requires a rebuild of catlas. In this section, we argue statistical effects of the fix on vertex partitioning.

#### 4.1 Distance profile

Here we compute the frequency of the distance from every vertex to its assigned dominator in the *induced subgraph* on each piece.

- dory, k21, r1
  - before: {0: 580, 1: 150, 2: 5, 3: 1}
    - Note: Distance exceeds r because of the bug.
  - after: {0: 580, 1: 156}
- dory, k21, r2
  - before: {0: 487, 1: 153, 2: 93, 3: 3}
  - after: {0: 487, 1: 159, 2: 90}
- dory, k21, r3
  - before: {0: 486, 1: 152, 2: 94, 3: 3, 4: 1}
  - after: {0: 486, 1: 158, 2: 92}
- twofoo, k31, r1
  - before: {0: 125324, 1: 72533, 2: 7784, 3: 245, 4: 5}
  - after: {0: 125324, 1: 80567}
- twofoo, k31, r2
  - before: {0: 83436, 1: 71977, 2: 47350, 3: 2827, 4: 275, 5: 25, 6: 1}
  - after: {0: 83436, 1: 83770, 2: 38685}
- twofoo, k31, r3
  - before: {0: 80344, 1: 70202, 2: 49941, 3: 4904, 4: 454, 5: 43, 6: 3}
  - after: {0: 80344, 1: 79444, 2: 45057, 3: 1046})

#### 4.2 Piece size changes

- dory, k21, r1

before: mean=1.27, min=1, max=4, Q1=1.00, median=1.00, Q3=1.00, variance=0.34, stddev=0.59
after: mean=1.27, min=1, max=4, Q1=1.00, median=1.00, Q3=1.00, variance=0.34, stddev=0.59
changes:

```
-2: 10
-1: 17
0: 525
1: 19
2: 9
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|total|
|:--:|--:|--:|--:|--:|--:|
|1|444|9|9|0|462|
|2|12|64|9|0|85|
|3|9|2|16|1|28|
|4|0|1|3|1|5|
|total|465|76|37|2|580|

- dory, k21, r2

before: mean=1.51, min=1, max=7, Q1=1.00, median=1.00, Q3=1.00, variance=1.15, stddev=1.07
after: mean=1.51, min=1, max=6, Q1=1.00, median=1.00, Q3=1.00, variance=1.11, stddev=1.05
changes:

```
-3: 4
-2: 11
-1: 10
0: 435
1: 13
2: 11
3: 3
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|5|6|7|total|
|:--:|--:|--:|--:|--:|--:|--:|--:|--:|
|1|362|1|11|0|0|0|0|374|
|2|9|6|9|0|2|0|0|26|
|3|9|0|48|1|0|0|0|58|
|4|3|0|0|7|2|0|1|13|
|5|0|0|1|1|10|0|0|12|
|6|0|0|1|1|0|2|0|4|
|7|0|0|0|0|0|0|0|0|
|total|383|7|70|10|14|2|1|487|

- dory, k21, r3

before: mean=1.51, min=1, max=7, Q1=1.00, median=1.00, Q3=1.00, variance=1.17, stddev=1.08
after: mean=1.51, min=1, max=7, Q1=1.00, median=1.00, Q3=1.00, variance=1.14, stddev=1.07
changes:

```
-4: 1
-3: 3
-2: 11
-1: 10
0: 434
1: 12
2: 12
3: 3
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|5|6|7|total|
|:--:|--:|--:|--:|--:|--:|--:|--:|--:|
|1|362|0|12|0|0|0|0|374|
|2|9|5|9|0|2|0|0|25|
|3|9|0|48|1|0|0|0|58|
|4|3|0|0|6|2|0|1|12|
|5|0|0|1|1|11|0|0|13|
|6|0|0|0|1|0|2|0|3|
|7|0|0|1|0|0|0|0|1|
|total|383|5|71|9|15|2|1|486|

- twofoo, k31, r1

before: mean=1.64, min=1, max=6, Q1=1.00, median=1.00, Q3=2.00, variance=0.79, stddev=0.89
after: mean=1.64, min=1, max=8, Q1=1.00, median=1.00, Q3=2.00, variance=0.87, stddev=0.93
changes:

```
-6: 1
-5: 2
-4: 12
-3: 167
-2: 1749
-1: 13426
0: 94409
1: 13717
2: 1756
3: 80
4: 5
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|5|6|7|8|total|
|:--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
|1|67385|6577|1291|52|5|0|0|0|75310|
|2|6436|14365|5963|357|28|0|0|0|27149|
|3|780|3531|11380|906|107|0|0|0|16704|
|4|72|410|3132|990|269|1|0|0|4874|
|5|3|35|525|221|289|2|0|0|1075|
|6|0|2|55|24|106|0|0|0|187|
|7|1|0|7|4|10|0|0|0|22|
|8|0|0|2|0|1|0|0|0|3|
|total|74677|24920|22355|2554|815|3|0|0|125324|

- twofoo, k31, r2

before: mean=2.47, min=1, max=9, Q1=1.00, median=2.00, Q3=4.00, variance=2.87, stddev=1.70
after: mean=2.47, min=1, max=12, Q1=1.00, median=2.00, Q3=4.00, variance=3.34, stddev=1.83
changes:

```
-7: 5
-6: 17
-5: 119
-4: 423
-3: 1527
-2: 4125
-1: 8476
0: 52978
1: 9853
2: 4276
3: 1288
4: 290
5: 52
6: 7
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|5|6|7|8|9|10|11|12|total|
|:--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
|1|37056|2417|1261|530|191|34|7|0|0|0|0|0|41496|
|2|891|3783|2570|1333|440|55|14|0|0|0|0|0|9086|
|3|572|1751|3962|2030|1028|207|38|4|0|0|0|0|9592|
|4|321|929|1949|3973|1674|427|92|6|0|0|0|0|9371|
|5|129|414|894|2053|2586|784|183|18|0|0|0|0|7061|
|6|50|96|300|980|1227|1186|302|41|1|0|0|0|4183|
|7|9|23|77|303|528|488|359|71|3|0|0|0|1861|
|8|1|2|18|80|128|190|102|73|5|0|0|0|599|
|9|0|0|3|20|29|44|28|14|0|0|0|0|138|
|10|0|0|3|3|5|11|16|3|1|0|0|0|42|
|11|0|0|0|0|0|3|0|1|1|0|0|0|5|
|12|0|0|0|0|1|0|0|1|0|0|0|0|2|
|total|39029|9415|11037|11305|7837|3429|1141|232|11|0|0|0|83436|

- twofoo, k31, r3

before: mean=2.56, min=1, max=12, Q1=1.00, median=2.00, Q3=4.00, variance=3.39, stddev=1.84
after: mean=2.56, min=1, max=13, Q1=1.00, median=2.00, Q3=4.00, variance=3.80, stddev=1.95
changes:

```
-10: 1
-8: 4
-7: 6
-6: 38
-5: 126
-4: 435
-3: 1521
-2: 3809
-1: 7778
0: 52257
1: 8492
2: 4045
3: 1392
4: 343
5: 78
6: 16
7: 2
11: 1
```

|after:size →<br>\\<br>↓before:size|1|2|3|4|5|6|7|8|9|10|11|12|13|total|
|:--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
|1|37027|1248|939|479|203|58|15|1|0|0|0|1|0|39971|
|2|832|3082|2095|1217|474|72|16|1|1|0|0|0|0|7790|
|3|531|1412|3455|1913|1028|265|55|4|0|0|0|0|0|8663|
|4|344|755|1574|3705|1704|537|138|11|0|0|0|0|0|8768|
|5|140|348|749|1793|2751|971|249|30|2|0|0|0|0|7033|
|6|54|93|275|863|1262|1494|415|62|5|0|0|0|0|4523|
|7|18|19|71|281|575|662|572|128|12|1|0|0|0|2339|
|8|3|3|14|69|171|245|191|148|16|1|0|0|0|861|
|9|3|0|9|19|39|72|72|41|21|1|0|0|0|277|
|10|0|0|2|7|18|15|23|18|10|2|1|0|0|96|
|11|1|0|1|0|1|0|3|7|1|1|0|0|0|15|
|12|0|0|0|0|1|0|2|4|0|0|0|0|0|7|
|13|0|0|0|0|0|0|0|0|1|0|0|0|0|1|
|total|38953|6960|9184|10346|8227|4391|1751|455|69|6|1|1|0|80344|

#### 4.3 Tie-breaking

Here we compute the frequency of the number of closest dominators for every vertex. If this number is 1, then there is only one closest dominator and thus no room for tie-breaking.

- dory, k21, r1

```
1: 605
2: 101
3: 11
4: 19
```

- dory, k21, r2

```
1: 633
2: 99
3: 2
4: 2
```

- dory, k21, r3

```
1: 633
2: 98
3: 3
4: 2
```

- twofoo, k31, r1

```
1: 149075
2: 27232
3: 17407
4: 12154
5: 23
```

- twofoo, k31, r2

```
1: 153255
2: 41108
3: 9688
4: 1769
5: 53
6: 18
```

- twofoo, k31, r3

```
1: 153393
2: 41374
3: 9306
4: 1694
5: 84
6: 39
7: 1
```
